### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ZI Library for wonderful Android development
 1) Components
 -------------
 
-* ProviderPreference, shared preferences accross processes built on ContentProvider
+* ProviderPreference, shared preferences across processes built on ContentProvider
 
 * ColorPicker, a color picker widget easy to use, thanks to Daniel Nilsson
 


### PR DESCRIPTION
@yixia, I've corrected a typographical error in the documentation of the [ZI](https://github.com/yixia/ZI) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
